### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-itertools
 termcolor
 tqdm


### PR DESCRIPTION
itertools are installed by default

example:
pip3 install itertools          
ERROR: Could not find a version that satisfies the requirement itertools (from versions: none)
ERROR: No matching distribution found for itertools