### PR TITLE
Update GitDorker.py

### DIFF
--- a/GitDorker.py
+++ b/GitDorker.py
@@ -69,7 +69,7 @@ if args.token:
 
 if args.tokenfile:
     with open(args.tokenfile) as f:
-        tokens_list = f.read().splitlines()
+        tokens_list = [i.strip() for i in f.read().splitlines() if i.strip()]
 
 if not len(tokens_list):
     parser.error('auth token is missing')


### PR DESCRIPTION
Ignoring lines that contain whitespaces and nothing else on token file.
Some text editors add one `\n` at end of file which was retrieved as a token before.
